### PR TITLE
translate filter support for I18n interpolation

### DIFF
--- a/lib/liquid-rails/filters/translate_filter.rb
+++ b/lib/liquid-rails/filters/translate_filter.rb
@@ -1,10 +1,11 @@
 module Liquid
   module Rails
     module TranslateFilter
-      def translate(key, locale = nil, scope = nil)
+      def translate(key, locale = nil, scope = nil, options = Hash.new)
         locale ||= ::I18n.locale.to_s
+        options.merge!({locale: locale, scope: scope})
 
-        @context.registers[:view].translate(key.to_s, locale: locale, scope: scope)
+        @context.registers[:view].translate(key.to_s, options.with_indifferent_access)
       end
     end
   end

--- a/spec/dummy/config/locales/en.yml
+++ b/spec/dummy/config/locales/en.yml
@@ -1,4 +1,5 @@
 en:
   welcome: 'Welcome everyone!'
+  welcome_name: 'Welcome, %{name}'
   links:
     home: 'Home'

--- a/spec/dummy/config/locales/km.yml
+++ b/spec/dummy/config/locales/km.yml
@@ -1,4 +1,5 @@
 km:
   welcome: 'សូមស្វាគមន៍'
+  welcome_name: 'សូមស្វាគមន៍ %{name}'
   links:
     home: 'ទំព័រដើម'

--- a/spec/lib/liquid-rails/filters/translate_filter_spec.rb
+++ b/spec/lib/liquid-rails/filters/translate_filter_spec.rb
@@ -20,6 +20,10 @@ module Liquid
       it 'translate with scope' do
         expect(::Liquid::Variable.new("'home' | translate: 'km', 'links'").render(context)).to eq('ទំព័រដើម')
       end
+
+      it 'translate with interpolation' do
+        expect(::Liquid::Variable.new("'welcome_name' | translate: 'en', nil, name: 'Jeremy'").render(context)).to eq('Welcome, Jeremy')
+      end
     end
   end
 end


### PR DESCRIPTION
First of all, thanks for awesome gem. Saved me a lot of time.

I needed a `translate` filter that'd accept an arbitrary hash and pass it over to Rails' `translate`, so that interpolation would work. This PR contains a working implementation.

I'd further suggest removing `scope` and `locale` from explicit function params and make everything work as hash: this way interpolation could be used without having to explicitly specifly `scope` and `locale` on every translation that needs interpolation vars. But this is a deeper change and I didn't want to change the api in backwards-incompatible way.