### PR TITLE
Use controller_path instead of controller_name for template path...

### DIFF
--- a/lib/liquid-rails/file_system.rb
+++ b/lib/liquid-rails/file_system.rb
@@ -4,9 +4,8 @@ module Liquid
   module Rails
     class FileSystem < ::Liquid::LocalFileSystem
       def read_template_file(template_path, context)
-        controller_name = context.registers[:controller].controller_name
-        template_path   = "#{controller_name}/#{template_path}" unless template_path.include?('/')
-
+        controller_path = context.registers[:controller].controller_path
+        template_path   = "#{controller_path}/#{template_path}" unless template_path.include?('/')
         super
       end
     end

--- a/spec/dummy/app/controllers/foospace/bar_controller.rb
+++ b/spec/dummy/app/controllers/foospace/bar_controller.rb
@@ -1,0 +1,5 @@
+class Foospace::BarController < ApplicationController
+  def index_partial
+    render layout: false
+  end
+end

--- a/spec/dummy/app/views/foospace/bar/_partial.liquid
+++ b/spec/dummy/app/views/foospace/bar/_partial.liquid
@@ -1,0 +1,1 @@
+Bar Partial

--- a/spec/dummy/app/views/foospace/bar/index_partial.liquid
+++ b/spec/dummy/app/views/foospace/bar/index_partial.liquid
@@ -1,0 +1,3 @@
+Foospace::BarController
+
+{% include 'partial' %}

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -7,4 +7,6 @@ Rails.application.routes.draw do
 
   get  '/index_partial',                to: 'home#index_partial'
   get  '/index_partial_with_full_path', to: 'home#index_partial_with_full_path'
+
+  get '/foospace/bar/index_partial',    to: 'foospace/bar#index_partial'
 end

--- a/spec/lib/liquid-rails/template_handler_spec.rb
+++ b/spec/lib/liquid-rails/template_handler_spec.rb
@@ -35,6 +35,12 @@ describe 'Request', type: :feature do
 
       expect(page.body).to eq "Application Layout\nLiquid on Rails\n\nHome Partial\nShared Partial"
     end
+
+    it 'respects namespace of original template for partials path' do
+      visit '/foospace/bar/index_partial'
+      expect(page.body.strip).to eq("Foospace::BarController\n\nBar Partial")
+    end
+
   end
 
   context 'render with filter' do


### PR DESCRIPTION
resolving. Makes partials in namespaces work.

Demonstrated in tests using `Foospace` namespace for `BarController` - putting `include partial` inside it tried to resolve `bar/partial` instead of `foospace/bar/partial`, like it should (and like Rails' partials work, always looking in current template path by default).