### PR TITLE
Configure the render_method and parsing function

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,18 @@ Check out more [examples](https://github.com/yoolk/liquid-rails/blob/master/spec
 
 It works for any ORMs. The PORO should include `Liquid::Rails::Droppable`. That's all you need to do to have your POROs supported.
 
+### Caching Compiled Templates
+
+In order to cache compiled templates, you may do something like the following in your application.rb (using the excellent `concurrent-ruby` gem):
+```
+cached_templates = Concurrent::Map.new do |m, template|
+  Rails.logger.info "Compiling Template"
+  m[template] = ::Liquid::Template.parse(template)
+end
+app.config.liquid_rails.render_method = :render!
+app.config.liquid_rails.parse_template = lambda { |template| cached_templates[template] }
+```
+
 ### RSpec
 
 In spec_helper.rb, you'll need to require the matchers:

--- a/lib/liquid-rails.rb
+++ b/lib/liquid-rails.rb
@@ -11,7 +11,7 @@ module Liquid
     autoload :Drop,             'liquid-rails/drops/drop'
     autoload :CollectionDrop,   'liquid-rails/drops/collection_drop'
 
-    Configuration = Struct.new(:render_method).new
+    Configuration = Struct.new(:render_method, :parse_template).new
 
     def self.setup_drop(base)
       base.class_eval do

--- a/lib/liquid-rails.rb
+++ b/lib/liquid-rails.rb
@@ -11,10 +11,16 @@ module Liquid
     autoload :Drop,             'liquid-rails/drops/drop'
     autoload :CollectionDrop,   'liquid-rails/drops/collection_drop'
 
+    Configuration = Struct.new(:render_method).new
+
     def self.setup_drop(base)
       base.class_eval do
         include Liquid::Rails::Droppable
       end
+    end
+
+    def self.configure
+      yield(Configuration)
     end
   end
 end

--- a/lib/liquid-rails/railtie.rb
+++ b/lib/liquid-rails/railtie.rb
@@ -2,6 +2,7 @@ module Liquid
   module Rails
     class Railtie < ::Rails::Railtie
       config.app_generators.template_engine :liquid
+      config.liquid_rails = ActiveSupport::OrderedOptions.new
 
       initializer 'liquid-rails.register_template_handler' do |app|
         ActiveSupport.on_load(:action_view) do
@@ -18,6 +19,14 @@ module Liquid
         [:active_record, :mongoid].each do |orm|
           ActiveSupport.on_load orm do
             Liquid::Rails.setup_drop self
+          end
+        end
+      end
+
+      config.after_initialize do
+        Liquid::Rails.configure do |liquid_config|
+          config.liquid_rails.each_pair do |key, value|
+            liquid_config[key] = value
           end
         end
       end

--- a/lib/liquid-rails/template_handler.rb
+++ b/lib/liquid-rails/template_handler.rb
@@ -12,6 +12,11 @@ module Liquid
         @helper     = ActionController::Base.helpers
       end
 
+      def render_method
+        return Configuration.render_method if Configuration.render_method
+        (::Rails.env.development? || ::Rails.env.test?) ? :render! : :render
+      end
+
       def render(template, local_assigns={})
         @view.controller.headers['Content-Type'] ||= 'text/html; charset=utf-8'
 
@@ -24,7 +29,6 @@ module Liquid
         assigns.merge!(local_assigns.stringify_keys)
 
         liquid = Liquid::Template.parse(template)
-        render_method = (::Rails.env.development? || ::Rails.env.test?) ? :render! : :render
         liquid.send(render_method, assigns, filters: filters, registers: { view: @view, controller: @controller, helper: @helper }).html_safe
       end
 

--- a/lib/liquid-rails/template_handler.rb
+++ b/lib/liquid-rails/template_handler.rb
@@ -17,6 +17,11 @@ module Liquid
         (::Rails.env.development? || ::Rails.env.test?) ? :render! : :render
       end
 
+      def parse(template)
+        return Configuration.parse_template.call(template) if Configuration.parse_template
+        Liquid::Template.parse(template)
+      end
+
       def render(template, local_assigns={})
         @view.controller.headers['Content-Type'] ||= 'text/html; charset=utf-8'
 
@@ -28,7 +33,7 @@ module Liquid
         assigns['content_for_layout'] = @view.content_for(:layout) if @view.content_for?(:layout)
         assigns.merge!(local_assigns.stringify_keys)
 
-        liquid = Liquid::Template.parse(template)
+        liquid = parse(template)
         liquid.send(render_method, assigns, filters: filters, registers: { view: @view, controller: @controller, helper: @helper }).html_safe
       end
 


### PR DESCRIPTION
This pull request adds the ability to set the render_method and parsing function. This allows you to put in a cache, to ensure the same template does not get compiled over and over again. This closes #18 